### PR TITLE
小説のItemから編集ページに遷移したときに、エラーが起こる問題を修正しました。設定画面とパスコード設定画面を作成しました。　ホームのbookItemのnill問題を解決。 PreviewページをPreviewでも表示できるように修正しました。

### DIFF
--- a/ScanBook.xcodeproj/project.pbxproj
+++ b/ScanBook.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		35882ADC2B9C976300079C48 /* PreviewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35882ADB2B9C976300079C48 /* PreviewModel.swift */; };
 		359B0DFC2BB5159B00F2A7E4 /* HomePage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359B0DFB2BB5159B00F2A7E4 /* HomePage.swift */; };
 		359CD2DD2BA57AA700BC7005 /* CustomAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359CD2DC2BA57AA700BC7005 /* CustomAlertView.swift */; };
+		35C1B2FB2BFE58B9008D7CB1 /* PassCodeSettingPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C1B2FA2BFE58B9008D7CB1 /* PassCodeSettingPage.swift */; };
+		35C1B2FD2C08008E008D7CB1 /* PasscodeSettingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C1B2FC2C08008E008D7CB1 /* PasscodeSettingModel.swift */; };
 		35D46DEA2BF33BFF00A605F5 /* BookDataItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D46DE92BF33BFF00A605F5 /* BookDataItem.swift */; };
 		35E13DC42BFB235E00F97C53 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E13DC32BFB235E00F97C53 /* LoadingView.swift */; };
 /* End PBXBuildFile section */
@@ -107,6 +109,8 @@
 		35882ADB2B9C976300079C48 /* PreviewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewModel.swift; sourceTree = "<group>"; };
 		359B0DFB2BB5159B00F2A7E4 /* HomePage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePage.swift; sourceTree = "<group>"; };
 		359CD2DC2BA57AA700BC7005 /* CustomAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAlertView.swift; sourceTree = "<group>"; };
+		35C1B2FA2BFE58B9008D7CB1 /* PassCodeSettingPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassCodeSettingPage.swift; sourceTree = "<group>"; };
+		35C1B2FC2C08008E008D7CB1 /* PasscodeSettingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasscodeSettingModel.swift; sourceTree = "<group>"; };
 		35D46DE92BF33BFF00A605F5 /* BookDataItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookDataItem.swift; sourceTree = "<group>"; };
 		35E13DC32BFB235E00F97C53 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -155,6 +159,7 @@
 				35315F832B6DE1B80045014B /* LibraryModel.swift */,
 				35882ADB2B9C976300079C48 /* PreviewModel.swift */,
 				350ED2652BBAA1970051A11E /* HomeModel.swift */,
+				35C1B2FC2C08008E008D7CB1 /* PasscodeSettingModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -270,6 +275,7 @@
 				35315F7F2B6974810045014B /* SettingPage.swift */,
 				35315F812B6DE1350045014B /* PreviewPage.swift */,
 				359B0DFB2BB5159B00F2A7E4 /* HomePage.swift */,
+				35C1B2FA2BFE58B9008D7CB1 /* PassCodeSettingPage.swift */,
 			);
 			path = Page;
 			sourceTree = "<group>";
@@ -432,10 +438,12 @@
 				35545F212B7E449D00B21AB4 /* view.swift in Sources */,
 				35545F232B7E44C000B21AB4 /* CustomBackButtonView.swift in Sources */,
 				35E13DC42BFB235E00F97C53 /* LoadingView.swift in Sources */,
+				35C1B2FD2C08008E008D7CB1 /* PasscodeSettingModel.swift in Sources */,
 				35882AD52B9A1F1500079C48 /* UIImageViewerView.swift in Sources */,
 				35315F8F2B6E271E0045014B /* PersistenceController.swift in Sources */,
 				35315F7E2B6142A20045014B /* DropDownView.swift in Sources */,
 				350ED2662BBAA1970051A11E /* HomeModel.swift in Sources */,
+				35C1B2FB2BFE58B9008D7CB1 /* PassCodeSettingPage.swift in Sources */,
 				35D46DEA2BF33BFF00A605F5 /* BookDataItem.swift in Sources */,
 				35545F1F2B79198300B21AB4 /* ScannerView.swift in Sources */,
 				3542558F2B4BDEBB00559413 /* LibraryPage.swift in Sources */,

--- a/ScanBook.xcodeproj/xcuserdata/isobekeito.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/ScanBook.xcodeproj/xcuserdata/isobekeito.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -116,5 +116,21 @@
             landmarkType = "7">
          </BreakpointContent>
       </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "ABC9748B-2F79-42FB-B1D6-FEC03C01B016"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "ScanBook/View/Page/PassCodeSettingPage.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "55"
+            endingLineNumber = "55"
+            landmarkName = "PassCodeLockItemButton"
+            landmarkType = "14">
+         </BreakpointContent>
+      </BreakpointProxy>
    </Breakpoints>
 </Bucket>

--- a/ScanBook/View/Page/HomePage.swift
+++ b/ScanBook/View/Page/HomePage.swift
@@ -159,7 +159,7 @@ struct ReadingBookItemView : View{
                     VStack(alignment:.leading) {
                         Group{
                             Text("カテゴリー：\(model.getCategoryStatusText(bookData.categoryStatus))")
-                            Text(bookData.title!).frame(height: Bounds.width * 0.04)
+                            Text(bookData.title ?? "" ).frame(height: Bounds.width * 0.04)
                             Text("\(bookData.pageCount + 1) / \(Convert.convertBase64ToImages(bookData.images!.components(separatedBy: ",")).count) ").font(.system(size: 20))
                         }.foregroundStyle(Color.white).fontWeight(.bold)
                     }

--- a/ScanBook/View/Page/PassCodeSettingPage.swift
+++ b/ScanBook/View/Page/PassCodeSettingPage.swift
@@ -1,0 +1,85 @@
+//
+//  PasscodeSettingPage.swift
+//  ScanBook
+//
+//  Created by 磯部馨仁 on 2024/05/23.
+//
+
+import SwiftUI
+
+struct PassCodeSettingPage: View {
+    @StateObject var passCodeModel: PasscodeSettingModel = PasscodeSettingModel()
+    var body: some View {
+        NavigationStack{
+            ZStack{
+                Color.black
+                    .ignoresSafeArea()
+                VStack {
+                    List{
+                        Section() {
+                            PassCodeLockItemButton(onTap: {
+                                passCodeModel.isPassCodeLock.toggle()
+                                if(passCodeModel.isPassCodeLock){
+                                    
+                                }else{
+                                    
+                                }
+                            }, model: passCodeModel  ).buttonStyle(BorderlessButtonStyle())
+                                .listRowSeparatorTint(.white)
+                                .listRowBackground(Color(white: 0.2, opacity: 1.0))
+                            
+                            FaceIdItemButton(model: passCodeModel,onTap: {
+                                passCodeModel.isFaceId.toggle()
+                                if(passCodeModel.isFaceId){
+                                    
+                                }else{
+                                    
+                                }
+                            }).buttonStyle(BorderlessButtonStyle()).listRowBackground(Color(white: 0.2, opacity: 1.0))
+                        }
+                  }.listStyle(.automatic)
+                    .listRowSeparatorTint(.white)
+                   .background(Color.black)
+                   .environment(\.defaultMinListRowHeight, 60)
+                   .scrollContentBackground(.hidden)
+                }.navigationBarTitle("パスコード設定", displayMode: .inline)
+                 .toolbarBackground(Color.black,for: .navigationBar)
+                 .toolbarBackground(.visible, for: .navigationBar)
+                 .toolbarColorScheme(.dark)
+                  .customBackButton(onBack: {})
+            }
+        }
+    }
+}
+
+struct PassCodeLockItemButton :View{
+    let onTap: ()-> Void
+    @ObservedObject var model: PasscodeSettingModel
+    var body: some View{
+        Button(action: onTap,label: {
+            HStack{
+                Text("パスワードロック").foregroundStyle(Color.white).bold().frame(maxWidth: .infinity, alignment: .leading)
+                Toggle("", isOn: $model.isPassCodeLock)
+            }
+        })
+    }
+}
+
+struct FaceIdItemButton:View{
+    @ObservedObject var model: PasscodeSettingModel
+    let onTap: ()-> Void
+    var body: some View{
+        Button(action: onTap,label: {
+            HStack{
+                Text("faceID").foregroundStyle(Color.white).bold().frame(maxWidth: .infinity, alignment: .leading)
+                Toggle("", isOn: $model.isFaceId)
+            }
+        })
+    }
+}
+
+
+
+#Preview {
+    PassCodeSettingPage()
+}

--- a/ScanBook/View/Page/PreviewPage.swift
+++ b/ScanBook/View/Page/PreviewPage.swift
@@ -79,32 +79,60 @@ struct PreviewPageCountBar:View{
     let imagesCount: Int
     @Binding @WithPrevious var pageCount: Int
     var body: some View{
-        ScrollView{
-            Menu {
-                ForEach(0..<imagesCount ,id: \.self){ page in
-                    Button(action: {
-                        pageCount = page
-                    }) {
-                        Text("\(page + 1)")
+        Menu{
+            ScrollView{
+                VStack{
+                    ForEach(0..<imagesCount ,id: \.self){ page in
+                        Button(action: {
+                            pageCount = page
+                        }) {
+                            Text("\(page + 1)")
+                        }
                     }
                 }
-            }label: {
-                HStack{
-                    Group{
-                        Text("\(pageCount + 1) /").font(.system(size: 20)).foregroundStyle(.gray)
-                        Text("\(imagesCount)").font(.system(size: 20))
-                            .foregroundStyle(.gray)
-                    }
-                }.padding(.horizontal).background(Color.white)
-                    .cornerRadius(30).frame(minWidth: 100.0)
-            }
+            }.frame(maxHeight: 100)
+        }label: {
+            HStack{
+                Group{
+                    Text("\(pageCount + 1) /").font(.system(size: 20)).foregroundStyle(.gray)
+                    Text("\(imagesCount)").font(.system(size: 20))
+                        .foregroundStyle(.gray)
+                }
+            }.padding(.horizontal).background(Color.white)
+                .cornerRadius(30)
         }
     }
+    
 }
 
 
 struct PreviewPage_Previews: PreviewProvider {
-    static let images :[UIImage] = []
+    static let images :[UIImage] = [
+        UIImage(systemName: "circle.fill")!,
+        UIImage(systemName: "circle.fill")!,
+        UIImage(systemName: "circle.fill")!,
+        UIImage(systemName: "circle.fill")!,
+        UIImage(systemName: "circle.fill")!,
+        UIImage(systemName: "circle.fill")!,
+        UIImage(systemName: "circle.fill")!,
+        UIImage(systemName: "circle.fill")!,
+        UIImage(systemName: "circle.fill")!,
+        UIImage(systemName: "circle.fill")!,
+        UIImage(systemName: "circle.fill")!,
+        UIImage(systemName: "circle.fill")!,
+        UIImage(systemName: "circle.fill")!,
+        UIImage(systemName: "circle.fill")!,
+        UIImage(systemName: "circle.fill")!,
+        UIImage(systemName: "circle.fill")!,
+        UIImage(systemName: "circle.fill")!,
+        UIImage(systemName: "circle.fill")!,
+        UIImage(systemName: "circle.fill")!,
+        UIImage(systemName: "circle.fill")!,
+        UIImage(systemName: "circle.fill")!,
+        UIImage(systemName: "circle.fill")!,
+        UIImage(systemName: "circle.fill")!,
+        UIImage(systemName: "circle.fill")!
+    ]
     static var previews: some View {
         PreviewPage(images: images, bookData: nil)
     }

--- a/ScanBook/View/Page/SettingPage.swift
+++ b/ScanBook/View/Page/SettingPage.swift
@@ -12,26 +12,37 @@ struct SettingPage: View {
         NavigationStack{
             ZStack{
                 Color.black.ignoresSafeArea()
-                VStack{
-                  List{
-                      Section(header: Text("設定").bold().foregroundStyle(Color.white)) {
-                          Text("パスコード").foregroundStyle(Color.white).bold().listRowBackground(Color(white: 0.2, opacity: 1.0)).onTapGesture {
-                              
-                          }
-                          Text("iCloud").foregroundStyle(Color.white).bold().listRowBackground(Color(white: 0.2, opacity: 1.0)).onTapGesture {
-                              
-                          }
-                      }
-                      Section(header: Text("利用規約・プライバシーポリシー").bold().foregroundStyle(Color.white)) {
-                          Text("プライバシーポリシー").bold().foregroundStyle(Color.white).listRowBackground(Color(white: 0.2, opacity: 1.0))
-                          Text("利用規約").bold().foregroundStyle(Color.white).listRowBackground(Color(white: 0.2, opacity: 1.0))
-                      }
-                      Section(header: Text("お問い合わせ").bold().foregroundStyle(Color.white)) {
-                          Text("お問い合わせ").bold().foregroundStyle(Color.white) .listRowBackground(Color(white: 0.2, opacity: 1.0))
-                      }
-                  }.listStyle(.sidebar)
-                   .background(Color.black)
-                   .scrollContentBackground(.hidden)
+                VStack {
+                    List{
+                        Section(header: Text("設定").bold().foregroundStyle(Color.white)) {
+                            NavigationLink(destination: PassCodeSettingPage()) {
+                                Text("パスコード").foregroundStyle(Color.white).bold()
+                                   
+                            } .listRowBackground(Color(white: 0.2, opacity: 1.0))
+                                .listRowSeparatorTint(.white)
+                            
+                            Text("iCloud").bold().foregroundStyle(Color.white)
+                                .listRowBackground(Color(white: 0.2, opacity: 1.0))
+                                .onTapGesture {
+                                    
+                                }
+                        }
+                        
+                        Section(header: Text("利用規約・プライバシーポリシー").bold().foregroundStyle(Color.white)) {
+                            Text("プライバシーポリシー").bold().foregroundStyle(Color.white)
+                                .listRowSeparatorTint(.white)
+                                .listRowBackground(Color(white: 0.2, opacity: 1.0)).onTapGesture{
+                                
+                            }
+                            Text("利用規約").bold().foregroundStyle(Color.white).listRowBackground(Color(white: 0.2, opacity: 1.0))
+                                .onTapGesture {}
+                        }
+                        Section(header: Text("お問い合わせ").bold().foregroundStyle(Color.white)) {
+                            Text("お問い合わせ").bold().foregroundStyle(Color.white) .listRowBackground(Color(white: 0.2, opacity: 1.0))
+                        }
+                    }.listStyle(.insetGrouped)
+                        .background(Color.black)
+                        .scrollContentBackground(.hidden)
                 }
             }.navigationTitle("設定").toolbarBackground(Color.black,for: .navigationBar)
                 .toolbarBackground(.visible, for: .navigationBar)

--- a/ScanBook/ViewModel/AddModel.swift
+++ b/ScanBook/ViewModel/AddModel.swift
@@ -17,7 +17,9 @@ class AddModel : ObservableObject{
             titleText = self.bookData!.title!
             categoryStatus = Int(self.bookData!.categoryStatus)
             category = categoryItems[categoryStatus!]
-            bookCovarImage = UIImage(data: self.bookData!.coverImage!)!;
+            if(category != "書類" ){
+                bookCovarImage = UIImage(data: self.bookData!.coverImage!)!;
+            }
             imageArray = Convert.convertBase64ToImages(self.bookData!.images!.components(separatedBy: ","))
             if(imageArray.count != 0){
                 pageCount = imageArray.count

--- a/ScanBook/ViewModel/PasscodeSettingModel.swift
+++ b/ScanBook/ViewModel/PasscodeSettingModel.swift
@@ -1,0 +1,11 @@
+//
+//  PasscodeSettingModel.swift
+//  ScanBook
+//
+//  Created by 磯部馨仁 on 2024/05/30.
+//
+import Foundation
+class PasscodeSettingModel: ObservableObject{
+    @Published var isPassCodeLock:Bool = false
+    @Published var isFaceId:Bool = false
+}


### PR DESCRIPTION
変更点

1. 小説のItemから編集ページに遷移したときに、エラーが起こる問題を修正しました
2. 設定画面とパスコード設定画面を作成しました。
3. ホームのbookItemのnill問題を解決。 
4. PreviewページをPreviewでも表示できるように修正しました。
